### PR TITLE
Fix commons-lang3:3.11 bug by downgrading.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -122,7 +122,7 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.13.1'
     implementation 'org.mnode.ical4j:ical4j:3.0.19'
     implementation 'com.sun.mail:javax.mail:1.6.2'
-    implementation 'org.apache.commons:commons-lang3:3.11'
+    implementation 'org.apache.commons:commons-lang3:3.9'
     implementation 'org.slf4j:slf4j-android:1.7.30'
     implementation 'com.github.lecho:hellocharts-library:1.5.8@aar'
     implementation "androidx.recyclerview:recyclerview:1.1.0"

--- a/app/src/main/java/org/voidsink/anewjkuapp/kusss/KusssHandler.java
+++ b/app/src/main/java/org/voidsink/anewjkuapp/kusss/KusssHandler.java
@@ -404,7 +404,10 @@ public class KusssHandler {
 
             body = response.body();
             if (!TextUtils.isEmpty(body)) {
-                iCal = calendarBuilder.build(new ByteArrayInputStream(body.getBytes(response.charset() != null ? response.charset() : Charset.defaultCharset().name())));
+                String charset = response.charset() != null ? response.charset() : Charset.defaultCharset().name();
+                ByteArrayInputStream calStream = new ByteArrayInputStream(body.getBytes(charset));
+                // breaks when upgrading commons.lang3 > 3.9
+                iCal = calendarBuilder.build(calStream);
             } else {
                 iCal = new Calendar();
             }


### PR DESCRIPTION
Warning: This bug only appears on systems that haven't yet loaded an ics timetable cal yet. So wiping data + cache + reinstalling app (or even better: wiping the emulator) is highly suggested for reproduction.

When using the current app on a blank emulator/phone, and updating the time table after logging in you get the exception (and the timetable doesn't load):
```
2020-10-02 14:32:05.716 4131-4180/org.voidsink.anewjkuapp.debug E/WM-WorkerWrapper: Work [ id=7980203f-bc2a-444e-83e2-2fd1bd9605ca, tags={ org.voidsink.anewjkuapp.worker.ImportCalendarWorker, UPDATE_CAL_LVA } ] failed because it threw an exception/error
    java.util.concurrent.ExecutionException: java.lang.NoSuchMethodError: No static method requireNonNull(Ljava/lang/Object;Ljava8/util/function/Supplier;)Ljava/lang/Object; in class Ljava/util/Objects; or its super classes (declaration of 'java.util.Objects' appears in /apex/com.android.runtime/javalib/core-oj.jar)
        at androidx.work.impl.utils.futures.AbstractFuture.getDoneValue(AbstractFuture.java:516)
        at androidx.work.impl.utils.futures.AbstractFuture.get(AbstractFuture.java:475)
        at androidx.work.impl.WorkerWrapper$2.run(WorkerWrapper.java:298)
        at androidx.work.impl.utils.SerialExecutor$Task.run(SerialExecutor.java:91)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:919)
     Caused by: java.lang.NoSuchMethodError: No static method requireNonNull(Ljava/lang/Object;Ljava8/util/function/Supplier;)Ljava/lang/Object; in class Ljava/util/Objects; or its super classes (declaration of 'java.util.Objects' appears in /apex/com.android.runtime/javalib/core-oj.jar)
        at org.apache.commons.lang3.Validate.notBlank(Validate.java:440)
        at net.fortuna.ical4j.model.TimeZoneRegistryImpl.getTimeZone(TimeZoneRegistryImpl.java:165)
        at net.fortuna.ical4j.data.DefaultContentHandler.resolveTimezones(DefaultContentHandler.java:183)
        at net.fortuna.ical4j.data.DefaultContentHandler.endCalendar(DefaultContentHandler.java:72)
        at net.fortuna.ical4j.data.CalendarParserImpl.parseCalendar(CalendarParserImpl.java:127)
        at net.fortuna.ical4j.data.CalendarParserImpl.parseCalendarList(CalendarParserImpl.java:180)
        at net.fortuna.ical4j.data.CalendarParserImpl.parse(CalendarParserImpl.java:149)
        at net.fortuna.ical4j.data.CalendarBuilder.build(CalendarBuilder.java:183)
        at net.fortuna.ical4j.data.CalendarBuilder.build(CalendarBuilder.java:171)
        at net.fortuna.ical4j.data.CalendarBuilder.build(CalendarBuilder.java:158)
        at org.voidsink.anewjkuapp.kusss.KusssHandler.loadIcalJsoup(KusssHandler.java:407)
        at org.voidsink.anewjkuapp.kusss.KusssHandler.loadIcal(KusssHandler.java:357)
        at org.voidsink.anewjkuapp.kusss.KusssHandler.getIcal(KusssHandler.java:322)
        at org.voidsink.anewjkuapp.worker.ImportCalendarWorker.importCalendar(ImportCalendarWorker.java:176)
        at org.voidsink.anewjkuapp.worker.ImportCalendarWorker.doWork(ImportCalendarWorker.java:102)
        at androidx.work.Worker$1.run(Worker.java:85)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167) 
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641) 
        at java.lang.Thread.run(Thread.java:919) 
```

This is an error in the KUSSS-Calendar-Exported-ICS importing.
Repeatedly git-downgrading until i found a version that works revealed that the breaking change was back on 5.4.2020 when commons:commons-lang3:3.9 was upgraded to 3.10.
Downgrading back to 3.9 fixes the issue.
However I couldn't find out why Objects.requireNonNull doesn't exist in that context / why it isn't detected compile time.

Tested on emulator + real phone.

2nd commit optional, to spot it when it breaks again easier.