### PR TITLE
Remove suffix for F-Droid

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,7 +81,6 @@ android {
         fdroid {
             dimension "tier"
             buildConfigField "boolean", "FOSS_ONLY", "true"
-            versionNameSuffix "-fdroid"
             return void // fix lint warning "Not all execution paths return a value"
         }
     }


### PR DESCRIPTION
...as it breaks autoupdate. Also it's clear that if it's not "-google" it's F-Droid, right?

Ref: https://f-droid.org/wiki/index.php?title=org.voidsink.anewjkuapp/lastbuild_140084&oldid=285825